### PR TITLE
fix: update sidebar URLs in _config.yml to match renamed category pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -52,23 +52,23 @@ menu:
     url:               /dms/
     submenu:
       - title:         ▫️AI
-        url:           /-ai/
+        url:           /dms-ai/
       - title:         ▫️Frontend
-        url:           /-frontend/
+        url:           /dms-frontend/
       - title:         ▫️Backend
-        url:           /-backend/
+        url:           /dms-backend/
       - title:         ▫️Devops
-        url:           /-devops/
+        url:           /dms-devops/
       - title:         ▫️Cloud
-        url:           /-cloud/
+        url:           /dms-cloud/
       - title:         ▫️DSA
-        url:           /-dsa/
+        url:           /dms-dsa/
       - title:         ▫️OS
-        url:           /-os/
+        url:           /dms-os/
       - title:         ▫️Network
-        url:           /-network/
+        url:           /dms-network/
       - title:         ▫️Database
-        url:           /-database/
+        url:           /dms-database/
   - title:             Devlog
     url:               /-devlog/
     submenu: 


### PR DESCRIPTION
Hardcoded sidebar menu URLs were still pointing to /-ai/, /-frontend/, etc. Updated all to /dms-ai/, /dms-frontend/, etc. to match renamed category files.

https://claude.ai/code/session_01JpLouxTmg97jDRikNb9Ezy